### PR TITLE
Fixed an incorrect mapping for the Return_URL

### DIFF
--- a/picketlink-authentication-facebook/README.md
+++ b/picketlink-authentication-facebook/README.md
@@ -69,7 +69,7 @@ This script adds the system-property valuse to the the server configuration. You
 
         #1 /system-property=FB_CLIENT_ID:add(value="YOUR_CLIENT_ID")
         #2 /system-property=FB_CLIENT_SECRET:add(value="YOUR_CLIENT_SECRET_CODE")
-        #3 /system-property=FB_CLIENT_RETURN_URL:add(value="YOUR_RETURN_URL/")
+        #3 /system-property=FB_RETURN_URL:add(value="YOUR_RETURN_URL/")
         The batch executed successfully.
         {"outcome" => "success"}
 
@@ -88,7 +88,7 @@ This script adds the system-property valuse to the the server configuration. You
 
 		[standalone@localhost:9999 /] /system-property=FB_CLIENT_ID:add(value="YOUR_CLIENT_ID")
 		[standalone@localhost:9999 /] /system-property=FB_CLIENT_SECRET:add(value="YOUR_CLIENT_SECRET_CODE")
-		[standalone@localhost:9999 /] /system-property=FB_CLIENT_RETURN_URL:add(value="YOUR_RETURN_URL/")
+		[standalone@localhost:9999 /] /system-property=FB_RETURN_URL:add(value="YOUR_RETURN_URL/")
 			
 		[standalone@localhost:9999 /] :reload
 
@@ -166,7 +166,7 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 
         #1 /system-property=FB_CLIENT_ID:remove
         #2 /system-property=FB_CLIENT_SECRET:remove
-        #3 /system-property=FB_CLIENT_RETURN_URL:remove
+        #3 /system-property=FB_RETURN_URL:remove
         The batch executed successfully.
         {"outcome" => "success"}
 

--- a/picketlink-authentication-facebook/configure-facebook.cli
+++ b/picketlink-authentication-facebook/configure-facebook.cli
@@ -6,7 +6,8 @@ batch
 ###       with the values provided when you registered as a Facebook developer.
 /system-property=FB_CLIENT_ID:add(value="YOUR_CLIENT_ID")
 /system-property=FB_CLIENT_SECRET:add(value="YOUR_CLIENT_SECRET_CODE")
-/system-property=FB_CLIENT_RETURN_URL:add(value="YOUR_RETURN_URL")
+/system-property=FB_RETURN_URL:add(value="YOUR_RETURN_URL")
+
 
 # Run the batch commands
 run-batch

--- a/picketlink-authentication-facebook/remove-facebook.cli
+++ b/picketlink-authentication-facebook/remove-facebook.cli
@@ -4,7 +4,7 @@ batch
 # Rmove the Facebook sytem-properties
 /system-property=FB_CLIENT_ID:remove
 /system-property=FB_CLIENT_SECRET:remove
-/system-property=FB_CLIENT_RETURN_URL:remove
+/system-property=FB_RETURN_URL:remove
 
 # Run the batch commands
 run-batch


### PR DESCRIPTION
Fixed the return url.  Quickstart wasn't working properly when using the CLI script.
